### PR TITLE
Add .gitattributes to mark package-lock.json as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+package-lock.json linguist-generated=true


### PR DESCRIPTION
## 📑 Description
Inserido o arquivo `package-lock.json` para que ele seja considerado um arquivo gerado, causando com que não tenha grandes numeros de linhas modificadas dentro de PRs ou da aba contribuiting para quem mudou esses arquivos.

## Additional Information
Não há utilidade de código nessa PR, sendo exclusivamente uma questão visual/organizacional e sem uma issue equivalente.